### PR TITLE
feat: add ci-watch slash command for Claude Code

### DIFF
--- a/modules/home-manager/programs/claude-code.nix
+++ b/modules/home-manager/programs/claude-code.nix
@@ -91,6 +91,42 @@ in
       };
     };
 
+    commands = {
+      "ci-watch.md" = ''
+        Watch the CI pipeline for the current branch and ensure it passes.
+        Use the GitHub CLI (`gh`) to monitor workflow runs.
+
+        ## Process
+
+        1. **Identify the current branch** with `git branch --show-current`
+        2. **Get the latest workflow run** for this branch:
+           ```
+           gh run list --branch <branch> --limit 1 --json databaseId,status,conclusion
+           ```
+        3. **Watch the run in real-time** until it completes:
+           ```
+           gh run watch <run-id> --exit-status
+           ```
+        4. **If the run succeeds** (exit code 0): report success and stop.
+        5. **If the run fails**:
+           a. Retrieve the failed job logs:
+              ```
+              gh run view <run-id> --log-failed
+              ```
+           b. Analyze the errors and fix the code.
+           c. Commit the fix with a clear message describing what was fixed.
+           d. Push to the current branch.
+           e. Wait a few seconds for the new run to be triggered, then go back to step 2.
+
+        ## Rules
+
+        - **Never give up**: keep looping until CI is fully green.
+        - **Each fix should be a separate commit** with a descriptive message.
+        - **Be surgical**: only change what is needed to fix the failing step.
+        - **If stuck after 5 consecutive failed attempts on the same error**, stop and ask the user for guidance.
+      '';
+    };
+
     agents = {
       "code-simplifier.md" = ''
         ---


### PR DESCRIPTION
Add a /ci-watch command that monitors GitHub Actions CI pipeline,
waits for completion, and enters an autonomous fix/commit/push loop
when failures are detected. Stops after CI is fully green or after
5 consecutive failed attempts on the same error.

https://claude.ai/code/session_01YN6sE4iCcb2dV9eMwZhdwX